### PR TITLE
Fixxed bigger or lower expression

### DIFF
--- a/src/main/kotlin/net/stckoverflw/dss/TwitterBot.kt
+++ b/src/main/kotlin/net/stckoverflw/dss/TwitterBot.kt
@@ -76,7 +76,7 @@ object TwitterBot {
         builder.append(
             if (difference > 7)
                 ":("
-            else if (difference >= 3)
+            else if (difference <= 3)
                 ":/"
             else if (difference == 0)
                 ":)"


### PR DESCRIPTION
This probably should mean that when the difference between the streams is smaller or equal to `3`.

# From
The difference was when `bigger` or `equal` to `3`. It actually never happend because the `else` statement never was run. (20. September 2021)

# To
I just flipped the expression to `smaller`. This should fix it